### PR TITLE
[+] add workflow updater

### DIFF
--- a/.github/workflows/update_manifest_beta.yml
+++ b/.github/workflows/update_manifest_beta.yml
@@ -1,0 +1,49 @@
+name: Update Cataclysm-DDA Commit in Manifest
+
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-manifest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2
+        with:
+          ref: beta
+
+      - name: Get latest commit and tag from the latest pre-release
+        run: |
+          RELEASE_DATA=$(curl -s https://api.github.com/repos/CleverRaven/Cataclysm-DDA/releases | jq -r '[.[] | select(.prerelease == true)] | .[0]')
+          
+          # Извлекаем тег из данных релиза
+          LATEST_TAG=$(echo "$RELEASE_DATA" | jq -r '.tag_name')
+          echo "Latest tag is $LATEST_TAG"
+          
+          # Извлекаем коммит из данных релиза
+          LATEST_COMMIT=$(echo "$RELEASE_DATA" | jq -r '.target_commitish')
+          echo "Latest commit is $LATEST_COMMIT"
+          
+          echo "LATEST_COMMIT=$LATEST_COMMIT" >> $GITHUB_ENV
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Update manifest with the latest commit
+        run: |
+          sed -i "s/commit: \".*\"/commit: \"$LATEST_COMMIT\"/" org.cataclysmdda.CataclysmDDA.yml
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+      - name: Commit and push changes with tag in message
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add org.cataclysmdda.CataclysmDDA.yml
+          git commit -m "Update manifest with latest Cataclysm-DDA commit $LATEST_COMMIT ($LATEST_TAG)"
+          git push origin beta
+


### PR DESCRIPTION
### Update Manifest with Latest Cataclysm-DDA Commit

**Description:**  
This pull request adds a new GitHub Actions workflow that automatically updates the `org.cataclysmdda.CataclysmDDA.yml` manifest with the latest commit from the most recent pre-release version of Cataclysm-DDA.

**Purpose:**  
The main goal of this change is to automate the process of updating the manifest to always use the latest commit from the pre-release version of Cataclysm-DDA. This reduces the need for manual intervention and ensures that the manifest is always synchronized with the latest updates in the project.

**Details of the Changes:**  
- Added a workflow that runs every 4 hours and can also be triggered manually.
- The workflow checks the latest pre-release on the Cataclysm-DDA GitHub repository, retrieves the tag and commit, and updates the manifest file with this information.
- It automatically commits and pushes the changes to the `beta` branch.

This change will keep the manifest up to date in the beta branch.