### PR TITLE
[u] cdda-experimental-2024-08-26-1250

### DIFF
--- a/org.cataclysmdda.CataclysmDDA.yml
+++ b/org.cataclysmdda.CataclysmDDA.yml
@@ -27,7 +27,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/CleverRaven/Cataclysm-DDA.git
-        commit: "4314562fbef305e45a2d7242c776cc3719e7c1fe"
+        commit: "911eeed478327576534edbf91e9c8fd8cfdb7e20"
       - type: file
         url: https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/dedfc2e5310b505a9728098d1b59777cb8b1e861/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
         sha256: ca7bf1a3a0598729440aaae73111ffa3992121fa19f0e36d988eee22055db29e


### PR DESCRIPTION
## What's Changed
* [MoM] Update Teleporter Documentation by @Standing-Storm in https://github.com/CleverRaven/Cataclysm-DDA/pull/75885
* towers are vaguely seen as tall buildings by @sonphantrung in https://github.com/CleverRaven/Cataclysm-DDA/pull/75879
* Isolation Protocol:  Add roguelike style health regen and pain reduction by @John-Candlebury in https://github.com/CleverRaven/Cataclysm-DDA/pull/75860
* Give the kitted survivor a smartphone by @bloodbowel in https://github.com/CleverRaven/Cataclysm-DDA/pull/75915


**Full Changelog**: https://github.com/CleverRaven/Cataclysm-DDA/compare/cdda-experimental-2024-08-26-0842...cdda-experimental-2024-08-26-1250
