### PR TITLE
[u] cdda-0.I-2025-08-07-1023

### DIFF
--- a/org.cataclysmdda.CataclysmDDA.yml
+++ b/org.cataclysmdda.CataclysmDDA.yml
@@ -24,4 +24,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/CleverRaven/Cataclysm-DDA.git
-        tag: cdda-0.I-2025-07-31-1856
+        tag: cdda-0.I-2025-08-07-1023


### PR DESCRIPTION
release: https://github.com/CleverRaven/Cataclysm-DDA/releases/tag/cdda-0.I-2025-08-07-1023